### PR TITLE
Add Indent helper func

### DIFF
--- a/docx/paragraph.go
+++ b/docx/paragraph.go
@@ -153,6 +153,30 @@ func (p *Paragraph) Numbering(id int, level int) {
 	p.ct.Property.NumProp.ILvl = ctypes.NewDecimalNum(level)
 }
 
+// Indent sets the paragraph indentation properties.
+//
+// This function assigns an indent definition to the paragraph,
+// which affects how exactly the paragraph is going to be indented.
+//
+// Parameters:
+//   - indentProp: A ctypes.Indent instance pointer representing exact indentation
+//     measurements to use.
+//
+// Example:
+//
+//	var size360 int = 360
+//	var sizeu420 uint64 = 420
+//	indent360 := ctypes.Indent{Left: &size360, Hanging: &sizeu420}
+//
+//	p1 := document.AddParagraph("Example indented para")
+//	p1.Indent(&indent360)
+func (p *Paragraph) Indent(indentProp *ctypes.Indent) {
+
+	p.ensureProp()
+
+	p.ct.Property.Indent = indentProp
+}
+
 // Appends a new text to the Paragraph.
 // Example:
 //

--- a/docx/paragraph_test.go
+++ b/docx/paragraph_test.go
@@ -93,6 +93,38 @@ func TestParagraph_Numbering(t *testing.T) {
 	f(4, 3, 4, 3)
 }
 
+func TestParagraph_Indent(t *testing.T) {
+	f := func(indentValue, expectedIndentValue ctypes.Indent) {
+		t.Helper()
+
+		p := &Paragraph{}
+
+		p.Indent(&indentValue)
+
+		assert.NotNil(t, p.ct.Property, "Expected ct.Property to be non-nil")
+		assert.NotNil(t, p.ct.Property.Indent, "Expected ct.Property.Indent to be non-nil")
+		assert.Equal(t, p.ct.Property.Indent, &expectedIndentValue, "Paragraph.Indent() value mismatch")
+	}
+
+	var size6 int = 6
+	var size360 int = 360
+	var sizeu420 uint64 = 420
+
+	indentLeft := ctypes.Indent{Left: &size360, Hanging: &sizeu420}
+	indentRight := ctypes.Indent{Right: &size360, Hanging: &sizeu420}
+	indentFirst := ctypes.Indent{FirstLine: &sizeu420}
+	indentLeftChars := ctypes.Indent{LeftChars: &size6}
+	indentRightChars := ctypes.Indent{RightChars: &size6}
+	indentFirstChars := ctypes.Indent{FirstLineChars: &size6}
+
+	f(indentLeft, indentLeft)
+	f(indentRight, indentRight)
+	f(indentFirst, indentFirst)
+	f(indentLeftChars, indentLeftChars)
+	f(indentRightChars, indentRightChars)
+	f(indentFirstChars, indentFirstChars)
+}
+
 func TestParagraph_AddText(t *testing.T) {
 	f := func(text string, expectedText string) {
 		t.Helper()


### PR DESCRIPTION
This change adds a function for adding an Indent definition directly to a paragraph

Previously, I had to add an indentation via the `ct.Properties` reference like so:
> `p1.GetCT().Property.Indent = &indentProp`

Semi-related to issue #59 where I couldn't indent a paragraph (there, a list) with just the `Style` property as per the Demo example.