### PR TITLE
Expose row and cell complex types

### DIFF
--- a/docx/table.go
+++ b/docx/table.go
@@ -196,6 +196,11 @@ type Row struct {
 	ct ctypes.Row
 }
 
+// getCt returns a pointer to the underlying Row Complex Type.
+func (r *Row) GetCt() *ctypes.Row {
+	return &r.ct
+}
+
 // Add Cell to row and returns Cell
 func (r *Row) AddCell() *Cell {
 	cell := Cell{
@@ -217,6 +222,11 @@ type Cell struct {
 
 	// Cell Complex Type
 	ct ctypes.Cell
+}
+
+// getCt returns a pointer to the underlying Cell Complex Type.
+func (c *Cell) GetCt() *ctypes.Cell {
+	return &c.ct
 }
 
 // Adds paragraph with text and returns Paragraph


### PR DESCRIPTION
This MR, once merged, will allow for more advanced table row/cell manipulation and formatting, including, eg, row height:

```
    rowCt := row.GetCt()
    rowCt.Property.Height = ctypes.NewTableRowHeight(500, stypes.HeightRuleExact)
```

And cell width:

```
    cell1Ct := cell1.GetCt()
    cell2Ct := cell2.GetCt()
    cell3Ct := cell3.GetCt()

    cell1Ct.Property.Width = ctypes.NewTableWidth(2000, stypes.TableWidthDxa)
    cell2Ct.Property.Width = ctypes.NewTableWidth(3000, stypes.TableWidthP
    cell3Ct.Property.Width = ctypes.NewTableWidth(0, stypes.TableWidthAuto)
```

It might be cleaner to expose cell-row level apis for different props... but this is simple and straightforward :) 