### PR TITLE
Add support for pict within a run

### DIFF
--- a/wml/ctypes/pict.go
+++ b/wml/ctypes/pict.go
@@ -1,0 +1,77 @@
+package ctypes
+
+import (
+	"encoding/xml"
+)
+
+type Pict struct {
+	Shape *Shape `xml:"shape,omitempty"`
+}
+
+// MarshalXML implements the xml.Marshaler interface.
+func (b Pict) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "w:pict"
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	if b.Shape != nil {
+		if err = b.Shape.MarshalXML(e, xml.StartElement{}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(xml.EndElement{Name: start.Name})
+}
+
+type Shape struct {
+	Type  string `xml:"type,attr,omitempty"`
+	Style string `xml:"style,attr,omitempty"`
+
+	ImageData *ImageData `xml:"imagedata,omitempty"`
+}
+
+// MarshalXML implements the xml.Marshaler interface.
+func (b Shape) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "v:shape"
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "type"}, Value: b.Type},
+		{Name: xml.Name{Local: "style"}, Value: b.Style},
+	}
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	if b.ImageData != nil {
+		if err := b.ImageData.MarshalXML(e, xml.StartElement{}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(xml.EndElement{Name: start.Name})
+}
+
+type ImageData struct {
+	RId   string `xml:"id,attr,omitempty"`
+	Title string `xml:"title,attr,omitempty"`
+}
+
+// MarshalXML implements the xml.Marshaler interface.
+func (b ImageData) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "v:imagedata"
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "r:id"}, Value: b.RId},
+		{Name: xml.Name{Local: "o:title"}, Value: b.Title},
+	}
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	return e.EncodeToken(xml.EndElement{Name: start.Name})
+}

--- a/wml/ctypes/pict_test.go
+++ b/wml/ctypes/pict_test.go
@@ -1,0 +1,66 @@
+package ctypes
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestPict_MarshalXML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Pict
+		expected string
+	}{
+		{
+			name:     "Empty Pict",
+			input:    Pict{},
+			expected: `<w:pict></w:pict>`,
+		},
+		{
+			name: "Pict with Shape",
+			input: Pict{
+				Shape: &Shape{
+					Type:  "rectangle",
+					Style: "width:100pt;height:50pt",
+				},
+			},
+			expected: `<w:pict><v:shape type="rectangle" style="width:100pt;height:50pt"></v:shape></w:pict>`,
+		},
+		{
+			name: "Pict with Shape and ImageData",
+			input: Pict{
+				Shape: &Shape{
+					Type:  "rectangle",
+					Style: "width:100pt;height:50pt",
+					ImageData: &ImageData{
+						RId:   "rId5",
+						Title: "image1.png",
+					},
+				},
+			},
+			expected: `<w:pict><v:shape type="rectangle" style="width:100pt;height:50pt"><v:imagedata r:id="rId5" o:title="image1.png"></v:imagedata></v:shape></w:pict>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result strings.Builder
+			encoder := xml.NewEncoder(&result)
+			start := xml.StartElement{Name: xml.Name{Local: "w:pict"}}
+
+			err := tt.input.MarshalXML(encoder, start)
+			if err != nil {
+				t.Fatalf("Error marshaling XML: %v", err)
+			}
+
+			if err = encoder.Flush(); err != nil {
+				t.Fatalf("Error flushing XML encoder: %v", err)
+			}
+
+			if result.String() != tt.expected {
+				t.Errorf("Expected XML:\n%s\nGot:\n%s", tt.expected, result.String())
+			}
+		})
+	}
+}

--- a/wml/ctypes/run.go
+++ b/wml/ctypes/run.go
@@ -2,7 +2,6 @@ package ctypes
 
 import (
 	"encoding/xml"
-
 	"github.com/gomutex/godocx/dml"
 	"github.com/gomutex/godocx/internal"
 	"github.com/gomutex/godocx/wml/stypes"
@@ -91,9 +90,11 @@ type RunChild struct {
 	//Tab Character
 	Tab *Empty `xml:"tab,omitempty"`
 
+	// Picture reference
+	Pict *Pict `xml:"pict,omitempty"`
+
 	//TODO:
 	// 	w:object    Inline Embedded Object
-	// w:pict    VML Object
 	// w:fldChar    Complex Field Character
 	// w:ruby    Phonetic Guide
 	// w:footnoteReference    Footnote Reference
@@ -213,6 +214,15 @@ loop:
 				r.Children = append(r.Children, RunChild{
 					Drawing: drawingElem,
 				})
+			case "pict":
+				pictElem := &Pict{}
+				if err = d.DecodeElement(pictElem, &elem); err != nil {
+					return err
+				}
+
+				r.Children = append(r.Children, RunChild{
+					Pict: pictElem,
+				})
 			default:
 				if err = d.Skip(); err != nil {
 					return err
@@ -301,6 +311,8 @@ func (r *Run) MarshalChild(e *xml.Encoder) error {
 			err = child.Tab.MarshalXML(e, xml.StartElement{Name: xml.Name{Local: "w:tab"}})
 		case child.Drawing != nil:
 			err = child.Drawing.MarshalXML(e, xml.StartElement{Name: xml.Name{Local: "w:drawing"}})
+		case child.Pict != nil:
+			err = child.Pict.MarshalXML(e, xml.StartElement{Name: xml.Name{Local: "w:pict"}})
 		case child.LastRenPgBrk != nil:
 			err = child.LastRenPgBrk.MarshalXML(e, xml.StartElement{Name: xml.Name{Local: "w:lastRenderedPageBreak"}})
 		case child.PTab != nil:


### PR DESCRIPTION
This adds barebones support for embedded `<pict>`s that contain a reference to an image stored (not inline) in the document archive.

I wasn't sure on naming the `RId` field, should it be `RID`? Should it even be exported? Open to suggestions.


Thanks!