### PR TITLE
feat: Add SVG MIME

### DIFF
--- a/docx/contentType.go
+++ b/docx/contentType.go
@@ -56,6 +56,8 @@ func MIMEFromExt(extension string) (string, error) {
 		return "image/jpeg", nil
 	case "png":
 		return "image/png", nil
+	case "svg":
+		return "image/svg+xml", nil
 	case "gif":
 		return "image/gif", nil
 	case "bmp":


### PR DESCRIPTION
This PR adds .svg to the known MIMEs to allow for insertion of SVG images to documents.