### PR TITLE
Avoid encoding empty titlePg values

### DIFF
--- a/wml/ctypes/sectionProp.go
+++ b/wml/ctypes/sectionProp.go
@@ -78,7 +78,7 @@ func (s SectionProp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		}
 	}
 
-	if s.TitlePg != nil {
+	if s.TitlePg != nil && s.TitlePg.Val != "" {
 		if err = s.TitlePg.MarshalXML(e, xml.StartElement{
 			Name: xml.Name{Local: "w:titlePg"},
 		}); err != nil {


### PR DESCRIPTION
We ran into an issue where taking a human-crafted word doc and modifying it with godocx would then lead to godocx not being able to parse the document, citing:

```
failed to open document: invalid OnOff string
```

I tracked this back to the `TitlePG` field on `ctypes.SectionProp`. Prior to modification by godocx, this was encoded as:
```
<w:titlePg/>
```

After modification with godocx, this would be encoded as:
```
<w:titlePg w:val=""></w:titlePg>
```

The empty string in Val would cause decoding to fail.

This PR fixes the issue, however, I am not sure this is the fully correct way to go.

Many `*OnOff` fields are just that (pointer to OnOff), but `TitlePG` is `*GenSingleStrVal[stypes.OnOff]` and `GenSingleStrVal` encodes regardless of whether the value it stores is empty. Rather than modifying `GenSingleStrVal`, which would probably break things, I opted to just not encode TitlePG when it is empty. Let me know if there's a better way to handle this.


Thanks!


