### PR TITLE
Update Underline constants and string mappings

### DIFF
--- a/wml/stypes/underline.go
+++ b/wml/stypes/underline.go
@@ -9,6 +9,7 @@ import (
 type Underline string
 
 const (
+	UnderlineInherited       Underline = ""
 	UnderlineNone            Underline = "none"
 	UnderlineSingle          Underline = "single"
 	UnderlineWords           Underline = "words"
@@ -18,11 +19,11 @@ const (
 	UnderlineDash            Underline = "dash"
 	UnderlineDotDash         Underline = "dotDash"
 	UnderlineDotDotDash      Underline = "dotDotDash"
-	UnderlineWavy            Underline = "wavy"
+	UnderlineWavy            Underline = "wave"
 	UnderlineDottedHeavy     Underline = "dottedHeavy"
-	UnderlineDashHeavy       Underline = "dashHeavy"
-	UnderlineDotDashHeavy    Underline = "dotDashHeavy"
-	UnderlineDotDotDashHeavy Underline = "dotDotDashHeavy"
+	UnderlineDashHeavy       Underline = "dashedHeavy"
+	UnderlineDotDashHeavy    Underline = "dashDotHeavy"
+	UnderlineDotDotDashHeavy Underline = "dashDotDotHeavy"
 	UnderlineWavyHeavy       Underline = "wavyHeavy"
 	UnderlineDashLong        Underline = "dashLong"
 	UnderlineWavyDouble      Underline = "wavyDouble"
@@ -31,6 +32,8 @@ const (
 
 func UnderlineFromStr(value string) (Underline, error) {
 	switch value {
+	case "":
+		return UnderlineInherited, nil
 	case "none":
 		return UnderlineNone, nil
 	case "single":
@@ -49,15 +52,15 @@ func UnderlineFromStr(value string) (Underline, error) {
 		return UnderlineDotDash, nil
 	case "dotDotDash":
 		return UnderlineDotDotDash, nil
-	case "wavy":
+	case "wave":
 		return UnderlineWavy, nil
 	case "dottedHeavy":
 		return UnderlineDottedHeavy, nil
-	case "dashHeavy":
+	case "dashedHeavy":
 		return UnderlineDashHeavy, nil
-	case "dotDashHeavy":
+	case "dashDotHeavy":
 		return UnderlineDotDashHeavy, nil
-	case "dotDotDashHeavy":
+	case "dashDotDotHeavy":
 		return UnderlineDotDotDashHeavy, nil
 	case "wavyHeavy":
 		return UnderlineWavyHeavy, nil

--- a/wml/stypes/underline_test.go
+++ b/wml/stypes/underline_test.go
@@ -10,6 +10,7 @@ func TestUnderlineFromStr_ValidValues(t *testing.T) {
 		input    string
 		expected Underline
 	}{
+		{"", UnderlineInherited},
 		{"none", UnderlineNone},
 		{"single", UnderlineSingle},
 		{"words", UnderlineWords},
@@ -19,11 +20,11 @@ func TestUnderlineFromStr_ValidValues(t *testing.T) {
 		{"dash", UnderlineDash},
 		{"dotDash", UnderlineDotDash},
 		{"dotDotDash", UnderlineDotDotDash},
-		{"wavy", UnderlineWavy},
+		{"wave", UnderlineWavy},
 		{"dottedHeavy", UnderlineDottedHeavy},
-		{"dashHeavy", UnderlineDashHeavy},
-		{"dotDashHeavy", UnderlineDotDashHeavy},
-		{"dotDotDashHeavy", UnderlineDotDotDashHeavy},
+		{"dashedHeavy", UnderlineDashHeavy},
+		{"dashDotHeavy", UnderlineDotDashHeavy},
+		{"dashDotDotHeavy", UnderlineDotDotDashHeavy},
 		{"wavyHeavy", UnderlineWavyHeavy},
 		{"dashLong", UnderlineDashLong},
 		{"wavyDouble", UnderlineWavyDouble},
@@ -64,6 +65,7 @@ func TestUnderline_UnmarshalXMLAttr_ValidValues(t *testing.T) {
 		inputXML string
 		expected Underline
 	}{
+		{`<element underline=""></element>`, UnderlineInherited},
 		{`<element underline="none"></element>`, UnderlineNone},
 		{`<element underline="single"></element>`, UnderlineSingle},
 		{`<element underline="words"></element>`, UnderlineWords},
@@ -73,11 +75,11 @@ func TestUnderline_UnmarshalXMLAttr_ValidValues(t *testing.T) {
 		{`<element underline="dash"></element>`, UnderlineDash},
 		{`<element underline="dotDash"></element>`, UnderlineDotDash},
 		{`<element underline="dotDotDash"></element>`, UnderlineDotDotDash},
-		{`<element underline="wavy"></element>`, UnderlineWavy},
+		{`<element underline="wave"></element>`, UnderlineWavy},
 		{`<element underline="dottedHeavy"></element>`, UnderlineDottedHeavy},
-		{`<element underline="dashHeavy"></element>`, UnderlineDashHeavy},
-		{`<element underline="dotDashHeavy"></element>`, UnderlineDotDashHeavy},
-		{`<element underline="dotDotDashHeavy"></element>`, UnderlineDotDotDashHeavy},
+		{`<element underline="dashedHeavy"></element>`, UnderlineDashHeavy},
+		{`<element underline="dashDotHeavy"></element>`, UnderlineDotDashHeavy},
+		{`<element underline="dashDotDotHeavy"></element>`, UnderlineDotDotDashHeavy},
 		{`<element underline="wavyHeavy"></element>`, UnderlineWavyHeavy},
 		{`<element underline="dashLong"></element>`, UnderlineDashLong},
 		{`<element underline="wavyDouble"></element>`, UnderlineWavyDouble},


### PR DESCRIPTION
When parsing DOCX files, multiple errors occurred while handling certain underline styles.
These changes aim to fix those errors and update the Underline constants and names to be accurate and complete.